### PR TITLE
Add Purpose/Approach/Usage/Examples sections to agent docs

### DIFF
--- a/agents/architect.md
+++ b/agents/architect.md
@@ -209,3 +209,19 @@ Example architecture for an AI-powered SaaS platform:
 - **10M users**: Event-driven architecture, distributed caching, multi-region
 
 **Remember**: Good architecture enables rapid development, easy maintenance, and confident scaling. The best architecture is simple, clear, and follows established patterns.
+
+# Agent: Architect
+
+## Purpose
+Provide senior-level architecture guidance to design scalable, maintainable systems and make informed technical decisions.
+
+## Approach
+Analyze the current architecture, gather functional and non-functional requirements, propose high-level designs, and document trade-offs and decisions using ADRs and checklists.
+
+## Usage
+Use when planning new features, refactoring large systems, or evaluating architectural patterns, scalability, and integration choices.
+
+## Examples
+- Assess whether to introduce an event-driven architecture for async workflows.
+- Design a caching strategy to improve API response times.
+- Compare monolith vs microservices for a growing product.

--- a/agents/build-error-resolver.md
+++ b/agents/build-error-resolver.md
@@ -279,3 +279,19 @@ new ClassPathResource("data/sample.json");
 - large refactor is requested
 - performance tuning
 - security review (use a security-focused agent)
+
+# Agent: Spring Boot Build Error Resolver
+
+## Purpose
+Resolve Spring Boot/Java build, compilation, and test failures quickly with minimal, targeted changes.
+
+## Approach
+Reproduce the failing build, classify errors (compile, dependency, context, tests), apply the smallest fix, and re-run the narrowest verification command.
+
+## Usage
+Use when Maven/Gradle builds fail, CI is red due to Java compile errors, Spring context startup failures, or broken tests.
+
+## Examples
+- Add a missing dependency to fix `package ... does not exist`.
+- Correct a method signature mismatch causing compilation errors.
+- Fix a misconfigured Spring property that breaks `@SpringBootTest`.

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -102,3 +102,19 @@ Add your project-specific checks here. Examples:
 - Validate cache fallback behavior
 
 Customize based on your project's `CLAUDE.md` or skill files.
+
+# Agent: Code Reviewer
+
+## Purpose
+Perform thorough code reviews to ensure quality, security, maintainability, and performance standards are met.
+
+## Approach
+Inspect recent diffs, evaluate changes against checklists, and report issues by priority with concrete fixes.
+
+## Usage
+Use immediately after code changes or before merging to catch defects, security risks, and regressions.
+
+## Examples
+- Review a new API endpoint for input validation and error handling.
+- Check a refactor for duplicated logic or missing tests.
+- Validate that secrets are not hardcoded in configuration updates.

--- a/agents/database-reviewer.md
+++ b/agents/database-reviewer.md
@@ -652,3 +652,19 @@ ORDER BY rank DESC;
 **Remember**: Database issues are often the root cause of application performance problems. Optimize queries and schema design early. Use EXPLAIN ANALYZE to verify assumptions. Always index foreign keys and RLS policy columns.
 
 *Patterns adapted from [Supabase Agent Skills](https://github.com/supabase/agent-skills) under MIT license.*
+
+# Agent: Database Reviewer
+
+## Purpose
+Ensure PostgreSQL schemas, queries, and security policies are performant, correct, and secure.
+
+## Approach
+Review SQL and migrations for indexing, data types, constraints, and RLS; analyze queries with EXPLAIN and validate concurrency and locking behavior.
+
+## Usage
+Use when writing SQL, creating migrations, designing schemas, or troubleshooting database performance.
+
+## Examples
+- Add a composite index to eliminate a sequential scan in a hot query.
+- Review RLS policies for multi-tenant tables using `auth.uid()`.
+- Validate foreign keys and constraints in a new migration.

--- a/agents/doc-updater.md
+++ b/agents/doc-updater.md
@@ -450,3 +450,19 @@ Before committing documentation:
 ---
 
 **Remember**: Documentation that doesn't match reality is worse than no documentation. Always generate from source of truth (the actual code).
+
+# Agent: Doc Updater
+
+## Purpose
+Keep codemaps and documentation aligned with the current codebase and architecture.
+
+## Approach
+Analyze repository structure, generate or update codemaps, refresh READMEs and guides, and ensure documentation reflects actual behavior.
+
+## Usage
+Use after significant code changes, new features, or architectural updates that require documentation updates.
+
+## Examples
+- Regenerate `docs/CODEMAPS/*` after adding a new service.
+- Update README setup steps after changing environment variables.
+- Add module documentation for a new package or API area.

--- a/agents/e2e-runner.md
+++ b/agents/e2e-runner.md
@@ -795,3 +795,19 @@ After E2E test run:
 ---
 
 **Remember**: E2E tests are your last line of defense before production. They catch integration issues that unit tests miss. Invest time in making them stable, fast, and comprehensive. For Example Project, focus especially on financial flows - one bug could cost users real money.
+
+# Agent: E2E Test Runner
+
+## Purpose
+Design, execute, and maintain end-to-end tests to validate critical user journeys with reliable artifacts.
+
+## Approach
+Prefer Agent Browser for semantic selectors, define stable test flows, manage flakiness, capture screenshots/videos/traces, and report results clearly.
+
+## Usage
+Use when adding or updating user flows, verifying releases, or investigating regressions in full-stack behavior.
+
+## Examples
+- Create a login → checkout → confirmation journey with screenshots.
+- Quarantine a flaky test and add retries with better waits.
+- Run E2E tests before deployment and attach HTML reports.

--- a/agents/go-build-resolver.md
+++ b/agents/go-build-resolver.md
@@ -366,3 +366,19 @@ Remaining Issues: list (if any)
 - **Document** any non-obvious fixes with inline comments
 
 Build errors should be fixed surgically. The goal is a working build, not a refactored codebase.
+
+# Agent: Go Build Error Resolver
+
+## Purpose
+Fix Go build, vet, and lint issues with minimal, targeted edits to restore a green build.
+
+## Approach
+Run `go build`, `go vet`, and linters to identify failures, apply the smallest correction, and re-run the narrowest checks.
+
+## Usage
+Use when Go compilation fails, `go vet` reports issues, or CI flags Go linting errors.
+
+## Examples
+- Add a missing import to resolve an undefined identifier.
+- Adjust pointer/value usage to satisfy an interface.
+- Fix an unused variable flagged by `go vet`.

--- a/agents/go-reviewer.md
+++ b/agents/go-reviewer.md
@@ -265,3 +265,19 @@ govulncheck ./...
 - Flag deprecated functions from standard library
 
 Review with the mindset: "Would this code pass review at Google or a top Go shop?"
+
+# Agent: Go Reviewer
+
+## Purpose
+Review Go code for idiomatic style, correctness, security, and performance.
+
+## Approach
+Inspect Go diffs, run `go vet`/`staticcheck` when available, and assess error handling, concurrency safety, and API design.
+
+## Usage
+Use after any Go code changes to ensure adherence to Go best practices before merging.
+
+## Examples
+- Flag ignored errors in a new handler.
+- Review goroutine usage for race conditions.
+- Suggest replacing string concatenation queries with parameterized SQL.

--- a/agents/planner-tdd.md
+++ b/agents/planner-tdd.md
@@ -280,3 +280,19 @@ When creating plans, NEVER:
 8. Estimate timeline
 
 Remember: Your output will be used by developers following strict TDD. Be specific, comprehensive, and always emphasize the Red-Green-Refactor cycle.
+
+# Agent: Planner (TDD)
+
+## Purpose
+Create implementation plans organized around TDD milestones and property-based testing requirements.
+
+## Approach
+Extract requirements, map correctness properties to tests, structure milestones by architectural dependencies, and define Red-Green-Refactor steps for each task.
+
+## Usage
+Use when planning feature work that must follow test-first practices or when a TDD-focused roadmap is required.
+
+## Examples
+- Plan a new authentication module with unit/property tests per milestone.
+- Break a search feature into TDD issues with Red-Green-Refactor steps.
+- Define acceptance criteria and testing strategy for each milestone.

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -117,3 +117,19 @@ Create detailed steps with:
 - Performance bottlenecks
 
 **Remember**: A great plan is specific, actionable, and considers both the happy path and edge cases. The best plans enable confident, incremental implementation.
+
+# Agent: Planner
+
+## Purpose
+Produce clear, actionable implementation plans for complex features or refactors.
+
+## Approach
+Analyze requirements, identify dependencies and risks, break work into phases with concrete steps, and define testing strategies.
+
+## Usage
+Use when a project needs a structured plan before coding or when decomposing complex changes.
+
+## Examples
+- Draft a phased plan for migrating a legacy API.
+- Break down a multi-step onboarding feature with dependencies.
+- Outline testing strategy for a refactor touching multiple modules.

--- a/agents/python-reviewer.md
+++ b/agents/python-reviewer.md
@@ -467,3 +467,19 @@ pytest --cov=app --cov-report=term-missing
 - **Async generators**: Proper async iteration
 
 Review with the mindset: "Would this code pass review at a top Python shop or open-source project?"
+
+# Agent: Python Reviewer
+
+## Purpose
+Review Python code for PEP 8 compliance, security, correctness, and performance.
+
+## Approach
+Inspect diffs, run lint/type tools when available, and validate error handling, input safety, and framework-specific best practices.
+
+## Usage
+Use after any Python code changes to ensure quality and security before merge.
+
+## Examples
+- Flag unsafe `yaml.load` usage without a safe loader.
+- Suggest parameterized queries to avoid SQL injection.
+- Verify async functions await network calls properly.

--- a/agents/refactor-cleaner.md
+++ b/agents/refactor-cleaner.md
@@ -304,3 +304,19 @@ After cleanup session:
 ---
 
 **Remember**: Dead code is technical debt. Regular cleanup keeps the codebase maintainable and fast. But safety first - never remove code without understanding why it exists.
+
+# Agent: Refactor Cleaner
+
+## Purpose
+Identify and remove dead code, duplicates, and unused dependencies to keep the codebase lean and maintainable.
+
+## Approach
+Run analysis tools (knip/depcheck/ts-prune), assess risk, remove unused items in safe batches, and verify with tests.
+
+## Usage
+Use during dedicated cleanup efforts or after large refactors to prune unused code and dependencies.
+
+## Examples
+- Remove unused exports reported by `ts-prune`.
+- Delete unused npm dependencies flagged by `depcheck`.
+- Consolidate duplicated utility functions across modules.

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -543,3 +543,19 @@ After security review:
 ---
 
 **Remember**: Security is not optional, especially for platforms handling real money. One vulnerability can cost users real financial losses. Be thorough, be paranoid, be proactive.
+
+# Agent: Security Reviewer
+
+## Purpose
+Detect and remediate security vulnerabilities across code, configuration, and dependencies.
+
+## Approach
+Run automated scans, review high-risk areas (auth, inputs, storage), and evaluate against OWASP Top 10 with concrete mitigation guidance.
+
+## Usage
+Use after changes involving user input, authentication/authorization, API endpoints, or sensitive data handling.
+
+## Examples
+- Identify SQL injection risk and recommend parameterized queries.
+- Flag insecure JWT handling or missing password hashing.
+- Detect hardcoded secrets and advise rotation.

--- a/agents/tdd-guide.md
+++ b/agents/tdd-guide.md
@@ -278,3 +278,19 @@ npm test -- --coverage --ci
 ```
 
 **Remember**: No code without tests. Tests are not optional. They are the safety net that enables confident refactoring, rapid development, and production reliability.
+
+# Agent: TDD Guide
+
+## Purpose
+Enforce test-driven development to deliver reliable code with strong coverage.
+
+## Approach
+Apply the Red-Green-Refactor cycle, write tests first, and validate coverage thresholds before merging.
+
+## Usage
+Use when implementing new features, fixing bugs, or refactoring to ensure test-first workflows.
+
+## Examples
+- Write a failing unit test for a new service method before implementation.
+- Add integration tests for a new API endpoint and then implement it.
+- Refactor existing logic only after tests protect behavior.


### PR DESCRIPTION
### Motivation
- Standardize agent documentation by adding clear `Purpose`, `Approach`, `Usage`, and `Examples` sections so each agent has a consistent, consumable description. 
- Make it easier for contributors and automated systems to understand when and how to invoke each agent.

### Description
- Added `Purpose`, `Approach`, `Usage`, and `Examples` blocks to multiple agent markdown files to provide concise guidance tailored to each agent's responsibilities. 
- Updated the following files: `agents/architect.md`, `agents/build-error-resolver.md`, `agents/code-reviewer.md`, `agents/database-reviewer.md`, `agents/doc-updater.md`, `agents/e2e-runner.md`, `agents/go-build-resolver.md`, `agents/go-reviewer.md`, `agents/planner-tdd.md`, `agents/planner.md`, `agents/python-reviewer.md`, `agents/refactor-cleaner.md`, `agents/security-reviewer.md`, and `agents/tdd-guide.md`.
- Each addition is documentation-only and phrased to match the agent's existing role and checklists.

### Testing
- No automated tests were run because these are documentation-only changes. 
- Changes were validated by reviewing the updated files to ensure the new sections are present and consistent across agents.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698a5651e77c8321b92f9352c43950cf)