### PR TITLE
Add standardized documentation sections to SKILL.md files

### DIFF
--- a/skills/backend-patterns/SKILL.md
+++ b/skills/backend-patterns/SKILL.md
@@ -585,3 +585,28 @@ export async function GET(request: Request) {
 ```
 
 **Remember**: Backend patterns enable scalable, maintainable server-side applications. Choose patterns that fit your complexity level.
+
+# Skill: backend-patterns
+
+## Purpose
+Proveer patrones backend para APIs, servicios, repositorios, caching y observabilidad.
+
+## When to Use
+- Al diseñar endpoints REST o middlewares.
+- Para optimizar consultas y manejar errores.
+- Al añadir autenticación, rate limiting o colas.
+
+## Usage
+- Separa capas (controller/service/repo).
+- Aplica cache-aside y manejo centralizado de errores.
+- Usa patrones de logging estructurado.
+
+## Examples
+- Implementar un `MarketService` con repositorio.
+- Añadir rate limiting por IP.
+- Usar un error handler con `ApiError`.
+
+## Related Skills
+- postgres-patterns
+- security-review
+- frontend-patterns

--- a/skills/clickhouse-io/SKILL.md
+++ b/skills/clickhouse-io/SKILL.md
@@ -427,3 +427,27 @@ pgClient.on('notification', async (msg) => {
 - Review slow query log
 
 **Remember**: ClickHouse excels at analytical workloads. Design tables for your query patterns, batch inserts, and leverage materialized views for real-time aggregations.
+
+# Skill: clickhouse-io
+
+## Purpose
+Guiar el diseño de tablas, consultas y pipelines analíticos en ClickHouse.
+
+## When to Use
+- Al modelar datos OLAP o analytics de alto volumen.
+- Al optimizar queries, agregaciones y materialized views.
+- Para ingestion batch o streaming hacia ClickHouse.
+
+## Usage
+- Selecciona el engine (MergeTree/Agregating/Replace).
+- Define particionado y ordering keys según queries.
+- Inserta en batch y usa vistas materializadas para agregados.
+
+## Examples
+- Crear tabla MergeTree con partición mensual.
+- Definir vista materializada para métricas por hora.
+- Consultar retención con cohortes.
+
+## Related Skills
+- postgres-patterns
+- backend-patterns

--- a/skills/coding-standards/SKILL.md
+++ b/skills/coding-standards/SKILL.md
@@ -518,3 +518,27 @@ setTimeout(callback, DEBOUNCE_DELAY_MS)
 ```
 
 **Remember**: Code quality is not negotiable. Clear, maintainable code enables rapid development and confident refactoring.
+
+# Skill: coding-standards
+
+## Purpose
+Establecer estándares generales de calidad y estilo para TS/JS/React/Node.
+
+## When to Use
+- En cualquier trabajo de frontend o backend JavaScript/TypeScript.
+- Cuando necesitas consistencia en naming, APIs y estructura.
+
+## Usage
+- Prioriza legibilidad y simplicidad (KISS/DRY/YAGNI).
+- Mantén inmutabilidad con spread y tipos explícitos.
+- Sigue convenciones de API y validación de entradas.
+
+## Examples
+- Usar `useCallback`/`useMemo` para rendimiento.
+- Definir un esquema Zod para validar requests.
+- Estructurar responses con `success`, `data` y `error`.
+
+## Related Skills
+- frontend-patterns
+- backend-patterns
+- security-review

--- a/skills/configure-ecc/SKILL.md
+++ b/skills/configure-ecc/SKILL.md
@@ -296,3 +296,25 @@ Then print a summary report:
 ### "Path reference errors after project-level install"
 - Some skills assume `~/.claude/` paths. Run Step 4 verification to find and fix these.
 - For `continuous-learning-v2`, the `~/.claude/homunculus/` directory is always user-level — this is expected and not an error.
+
+# Skill: configure-ecc
+
+## Purpose
+Guiar la instalación interactiva de Everything Claude Code (skills y rules) a nivel usuario o proyecto.
+
+## When to Use
+- Cuando el usuario pide instalar o configurar ECC.
+- Para verificar y optimizar instalaciones existentes.
+
+## Usage
+- Clona el repo en `/tmp` y define el nivel de instalación.
+- Selecciona categorías/skills/rules con `AskUserQuestion`.
+- Verifica rutas y referencias cruzadas, luego optimiza si aplica.
+
+## Examples
+- Instalar skills de Database y Workflow en `~/.claude/`.
+- Ejecutar verificación de paths y corregir referencias.
+
+## Related Skills
+- continuous-learning-v2
+- strategic-compact

--- a/skills/continuous-learning-v2/SKILL.md
+++ b/skills/continuous-learning-v2/SKILL.md
@@ -282,3 +282,25 @@ v2 is fully compatible with v1:
 ---
 
 *Instinct-based learning: teaching Claude your patterns, one observation at a time.*
+
+# Skill: continuous-learning-v2
+
+## Purpose
+Capturar hábitos y patrones como “instincts” con hooks y evolucionarlos a skills/commands.
+
+## When to Use
+- Cuando quieres aprendizaje automático continuo en sesiones Claude Code.
+- Para generar skills a partir de observaciones reales.
+
+## Usage
+- Habilita hooks PreToolUse/PostToolUse.
+- Revisa instintos con `/instinct-status` y evoluciona con `/evolve`.
+- Configura rutas y thresholds en `config.json`.
+
+## Examples
+- Crear `~/.claude/homunculus/observations.jsonl`.
+- Exportar instintos con `/instinct-export`.
+
+## Related Skills
+- continuous-learning
+- strategic-compact

--- a/skills/continuous-learning/SKILL.md
+++ b/skills/continuous-learning/SKILL.md
@@ -108,3 +108,24 @@ Homunculus v2 takes a more sophisticated approach:
 5. **Evolution path** - Cluster related instincts into skills/commands
 
 See: `/Users/affoon/Documents/tasks/12-continuous-learning-v2.md` for full spec.
+
+# Skill: continuous-learning
+
+## Purpose
+Extraer patrones al final de cada sesión y guardarlos como skills aprendidas.
+
+## When to Use
+- Cuando deseas aprendizaje automático basado en sesiones.
+- Para convertir resoluciones recurrentes en skills reutilizables.
+
+## Usage
+- Configura el hook `Stop` en `~/.claude/settings.json`.
+- Ajusta `config.json` para umbrales y tipos de patrones.
+
+## Examples
+- Guardar skills en `~/.claude/skills/learned/`.
+- Cambiar `min_session_length` para activar extracción.
+
+## Related Skills
+- continuous-learning-v2
+- strategic-compact

--- a/skills/eval-harness/SKILL.md
+++ b/skills/eval-harness/SKILL.md
@@ -225,3 +225,25 @@ Capability: 5/5 passed (pass@3: 100%)
 Regression: 3/3 passed (pass^3: 100%)
 Status: SHIP IT
 ```
+
+# Skill: eval-harness
+
+## Purpose
+Implementar Eval-Driven Development con definiciones de evals, graders y reportes.
+
+## When to Use
+- Al definir criterios de éxito antes de programar.
+- Para prevenir regresiones y medir pass@k.
+
+## Usage
+- Define capability/regression evals antes de codificar.
+- Ejecuta `/eval check` y `/eval report`.
+- Guarda resultados y métricas en `.claude/evals/`.
+
+## Examples
+- Crear un eval para autenticación con criterios claros.
+- Reportar pass@1 y pass@3 en un feature.
+
+## Related Skills
+- verification-loop
+- tdd-workflow

--- a/skills/frontend-patterns/SKILL.md
+++ b/skills/frontend-patterns/SKILL.md
@@ -629,3 +629,26 @@ export function Modal({ isOpen, onClose, children }: ModalProps) {
 ```
 
 **Remember**: Modern frontend patterns enable maintainable, performant user interfaces. Choose patterns that fit your project complexity.
+
+# Skill: frontend-patterns
+
+## Purpose
+Ofrecer patrones de UI modernos en React/Next.js: composición, hooks, rendimiento y accesibilidad.
+
+## When to Use
+- Al construir componentes, formularios o flujos UI complejos.
+- Para mejorar performance con memoización o virtualización.
+
+## Usage
+- Prefiere composición y hooks reutilizables.
+- Aplica code-splitting y virtualización en listas largas.
+- Implementa errores y accesibilidad de forma explícita.
+
+## Examples
+- Crear `useDebounce` para búsquedas.
+- Usar `React.memo` para tarjetas de lista.
+- Implementar un `ErrorBoundary` global.
+
+## Related Skills
+- coding-standards
+- backend-patterns

--- a/skills/iterative-retrieval/SKILL.md
+++ b/skills/iterative-retrieval/SKILL.md
@@ -200,3 +200,24 @@ When retrieving context for this task:
 - [The Longform Guide](https://x.com/affaanmustafa/status/2014040193557471352) - Subagent orchestration section
 - `continuous-learning` skill - For patterns that improve over time
 - Agent definitions in `~/.claude/agents/`
+
+# Skill: iterative-retrieval
+
+## Purpose
+Resolver el problema de contexto en subagentes mediante refinamiento iterativo.
+
+## When to Use
+- Cuando el subagente no conoce los archivos relevantes.
+- Para tareas grandes con contexto incierto.
+
+## Usage
+- Ejecuta el loop DISPATCH → EVALUATE → REFINE → LOOP.
+- Limita a 3 ciclos y conserva archivos de alta relevancia.
+
+## Examples
+- Buscar errores de expiración de tokens con keywords refinadas.
+- Encontrar puntos de rate limiting en un API.
+
+## Related Skills
+- strategic-compact
+- continuous-learning-v2

--- a/skills/java-coding-standards/SKILL.md
+++ b/skills/java-coding-standards/SKILL.md
@@ -136,3 +136,25 @@ log.error("failed_fetch_market slug={}", slug, ex);
 - Favor deterministic tests; no hidden sleeps
 
 **Remember**: Keep code intentional, typed, and observable. Optimize for maintainability over micro-optimizations unless proven necessary.
+
+# Skill: java-coding-standards
+
+## Purpose
+Estandarizar el código Java en servicios Spring Boot: naming, inmutabilidad, Optional y excepciones.
+
+## When to Use
+- Al escribir o revisar código Java (17+) en backend.
+- Cuando se definan DTOs, servicios o repositorios.
+
+## Usage
+- Prefiere records y campos `final`.
+- Usa `Optional` correctamente y excepciones de dominio.
+- Mantén estructura de paquetes consistente.
+
+## Examples
+- Definir un `record` para DTOs inmutables.
+- Usar `Optional.map` y `orElseThrow` en repositorios.
+
+## Related Skills
+- springboot-patterns
+- springboot-tdd

--- a/skills/jpa-patterns/SKILL.md
+++ b/skills/jpa-patterns/SKILL.md
@@ -139,3 +139,25 @@ spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 - Assert SQL efficiency using logs: set `logging.level.org.hibernate.SQL=DEBUG` and `logging.level.org.hibernate.orm.jdbc.bind=TRACE` for parameter values
 
 **Remember**: Keep entities lean, queries intentional, and transactions short. Prevent N+1 with fetch strategies and projections, and index for your read/write paths.
+
+# Skill: jpa-patterns
+
+## Purpose
+Guiar el diseño de entidades JPA/Hibernate, relaciones y performance.
+
+## When to Use
+- Al modelar entidades, repositorios y transacciones.
+- Para evitar N+1 y optimizar queries.
+
+## Usage
+- Define índices y estrategias de fetch.
+- Usa `@Transactional` con lectura optimizada.
+- Añade tests con `@DataJpaTest`.
+
+## Examples
+- Crear entidad con índices y auditing.
+- Usar `JOIN FETCH` para evitar N+1.
+
+## Related Skills
+- springboot-patterns
+- postgres-patterns

--- a/skills/nutrient-document-processing/SKILL.md
+++ b/skills/nutrient-document-processing/SKILL.md
@@ -163,3 +163,26 @@ For native tool integration, use the MCP server instead of curl:
 - [Full API Docs](https://www.nutrient.io/guides/dws-processor/)
 - [Agent Skill Repo](https://github.com/PSPDFKit-labs/nutrient-agent-skill)
 - [npm MCP Server](https://www.npmjs.com/package/@nutrient-sdk/dws-mcp-server)
+
+# Skill: nutrient-document-processing
+
+## Purpose
+Procesar documentos con la API de Nutrient DWS: convertir formatos, OCR, extracción de texto/tablas, redacción, firmas y formularios.
+
+## When to Use
+- Conversión entre PDF, DOCX, XLSX, PPTX, HTML o imágenes.
+- Necesitas OCR, extracción de datos o redacción de PII.
+- Requieres firmar documentos o completar formularios PDF.
+
+## Usage
+- Configura `NUTRIENT_API_KEY`.
+- Envía requests multipart a `https://api.nutrient.io/build`.
+- Usa `instructions` para definir acciones (convert, ocr, redaction, sign, fillForm).
+
+## Examples
+- Convertir `document.docx` a PDF con curl.
+- Ejecutar OCR sobre un PDF escaneado.
+- Redactar emails y SSN con presets o regex.
+
+## Related Skills
+- security-review

--- a/skills/postgres-patterns/SKILL.md
+++ b/skills/postgres-patterns/SKILL.md
@@ -144,3 +144,28 @@ SELECT pg_reload_conf();
 ---
 
 *Based on [Supabase Agent Skills](https://github.com/supabase/agent-skills) (MIT License)*
+
+# Skill: postgres-patterns
+
+## Purpose
+Proveer patrones de diseño y optimización para PostgreSQL: índices, tipos de datos, RLS y tuning básico.
+
+## When to Use
+- Al escribir consultas SQL o migraciones.
+- Al definir esquemas e índices para rendimiento.
+- Cuando hay problemas de latencia o bloqueos.
+
+## Usage
+- Sigue el cheat sheet de índices y tipos de datos.
+- Aplica patrones comunes (UPSERT, paginación por cursor, SKIP LOCKED).
+- Ejecuta consultas de diagnóstico para encontrar anti-patrones.
+
+## Examples
+- Crear un índice parcial para filas activas.
+- Usar paginación por cursor en lugar de OFFSET.
+- Configurar `pg_stat_statements` para monitoreo.
+
+## Related Skills
+- clickhouse-io
+- backend-patterns
+- jpa-patterns

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -492,3 +492,27 @@ Before ANY production deployment:
 ---
 
 **Remember**: Security is not optional. One vulnerability can compromise the entire platform. When in doubt, err on the side of caution.
+
+# Skill: security-review
+
+## Purpose
+Checklist integral de seguridad para auth, inputs, secretos, endpoints y datos sensibles.
+
+## When to Use
+- Al manejar autenticación, autorizaciones o pagos.
+- Cuando se reciben inputs de usuarios o archivos.
+- Antes de lanzar a producción o crear PRs sensibles.
+
+## Usage
+- Revisa cada sección (secrets, validation, SQLi, XSS, CSRF, rate limit).
+- Añade tests de seguridad y validaciones.
+- Aplica políticas de logging y error handling seguro.
+
+## Examples
+- Validar requests con Zod.
+- Usar cookies httpOnly para tokens.
+- Añadir rate limiting a endpoints costosos.
+
+## Related Skills
+- springboot-security
+- backend-patterns

--- a/skills/springboot-patterns/SKILL.md
+++ b/skills/springboot-patterns/SKILL.md
@@ -302,3 +302,29 @@ Use Spring’s `@Scheduled` or integrate with queues (e.g., Kafka, SQS, RabbitMQ
 - Enforce null-safety via `@NonNull` and `Optional` where appropriate
 
 **Remember**: Keep controllers thin, services focused, repositories simple, and errors handled centrally. Optimize for maintainability and testability.
+
+# Skill: springboot-patterns
+
+## Purpose
+Guiar el diseño de servicios Spring Boot con patrones de arquitectura, API REST, servicios por capas, persistencia, cache, async y logging.
+
+## When to Use
+- Al diseñar controladores REST, servicios y repositorios en Spring Boot.
+- Cuando necesites caching, jobs en background, paginación o resiliencia.
+- Para establecer estándares de observabilidad y manejo de errores.
+
+## Usage
+- Define controladores delgados y servicios transaccionales.
+- Usa DTOs con validación, repositorios Spring Data y manejo centralizado de errores.
+- Aplica cache/async y filtros cuando el flujo lo requiera.
+
+## Examples
+- Crear un `@RestController` con validación y respuesta paginada.
+- Implementar un servicio con `@Transactional` y un repositorio JPA.
+- Añadir un filtro de logging o rate limiting con Bucket4j.
+
+## Related Skills
+- springboot-tdd
+- springboot-security
+- jpa-patterns
+- springboot-verification

--- a/skills/springboot-security/SKILL.md
+++ b/skills/springboot-security/SKILL.md
@@ -117,3 +117,27 @@ http
 - [ ] Logs free of sensitive data
 
 **Remember**: Deny by default, validate inputs, least privilege, and secure-by-configuration first.
+
+# Skill: springboot-security
+
+## Purpose
+Aplicar buenas prácticas de seguridad en Spring Boot: authn/authz, CSRF, headers, secrets y rate limiting.
+
+## When to Use
+- Al implementar autenticación/autorización.
+- Al crear endpoints y validar inputs.
+- Cuando se manejan secretos o datos sensibles.
+
+## Usage
+- Usa filtros de auth y `@PreAuthorize`.
+- Habilita validación con Bean Validation.
+- Configura headers de seguridad y políticas CSRF adecuadas.
+
+## Examples
+- Implementar `JwtAuthFilter` con `OncePerRequestFilter`.
+- Configurar CSP y `SameSite` en headers.
+
+## Related Skills
+- springboot-patterns
+- security-review
+- springboot-verification

--- a/skills/springboot-tdd/SKILL.md
+++ b/skills/springboot-tdd/SKILL.md
@@ -155,3 +155,27 @@ class MarketBuilder {
 - Gradle: `./gradlew test jacocoTestReport`
 
 **Remember**: Keep tests fast, isolated, and deterministic. Test behavior, not implementation details.
+
+# Skill: springboot-tdd
+
+## Purpose
+Aplicar TDD en Spring Boot con JUnit 5, Mockito, MockMvc, Testcontainers y JaCoCo.
+
+## When to Use
+- Al crear endpoints, servicios o repositorios.
+- Cuando se corrigen bugs o se refactoriza.
+
+## Usage
+- Escribe tests unitarios, web e integración antes del código.
+- Usa Testcontainers para entornos reales.
+- Verifica cobertura con JaCoCo.
+
+## Examples
+- `@WebMvcTest` para controladores.
+- `@DataJpaTest` con Testcontainers.
+- `@SpringBootTest` para flujos completos.
+
+## Related Skills
+- springboot-patterns
+- springboot-verification
+- jpa-patterns

--- a/skills/springboot-verification/SKILL.md
+++ b/skills/springboot-verification/SKILL.md
@@ -98,3 +98,24 @@ Issues to Fix:
 - Keep a short loop: `mvn -T 4 test` + spotbugs for quick feedback
 
 **Remember**: Fast feedback beats late surprises. Keep the gate strict—treat warnings as defects in production systems.
+
+# Skill: springboot-verification
+
+## Purpose
+Asegurar calidad en proyectos Spring Boot con builds, análisis estático, tests y scans.
+
+## When to Use
+- Antes de PRs o releases.
+- Después de cambios significativos en backend Java.
+
+## Usage
+- Ejecuta build, static analysis, tests y security scans.
+- Revisa diffs para detectar cambios no deseados.
+
+## Examples
+- `mvn -T 4 clean verify -DskipTests`.
+- `mvn jacoco:report` para cobertura.
+
+## Related Skills
+- springboot-tdd
+- springboot-security

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -61,3 +61,24 @@ Environment variables:
 
 - [The Longform Guide](https://x.com/affaanmustafa/status/2014040193557471352) - Token optimization section
 - Memory persistence hooks - For state that survives compaction
+
+# Skill: strategic-compact
+
+## Purpose
+Sugerir compacción manual en puntos lógicos para conservar contexto clave.
+
+## When to Use
+- Sesiones largas con muchas herramientas.
+- Antes/después de cambios de fase (exploración → implementación).
+
+## Usage
+- Instala el hook `PreToolUse` con `suggest-compact.sh`.
+- Ajusta `COMPACT_THRESHOLD` si necesitas más o menos frecuencia.
+
+## Examples
+- Configurar `~/.claude/settings.json` con el hook.
+- Compactar tras completar un milestone.
+
+## Related Skills
+- iterative-retrieval
+- continuous-learning

--- a/skills/tdd-milestone-planning/SKILL.md
+++ b/skills/tdd-milestone-planning/SKILL.md
@@ -315,3 +315,25 @@ Cuando implementes una tarea:
 - **Property-Based Testing**: "Property-Based Testing with PropEr, Erlang, and Elixir"
 - **Clean Code**: Robert C. Martin - "Clean Code"
 - **Documentation**: "Docs as Code" methodology
+
+# Skill: tdd-milestone-planning
+
+## Purpose
+Planificar milestones e issues con TDD estricto y property-based testing.
+
+## When to Use
+- Al descomponer proyectos grandes en milestones.
+- Para definir issues con criterios de aceptación claros.
+
+## Usage
+- Sigue la estructura de issue propuesta.
+- Mapea properties a property tests con 100+ iteraciones.
+- Incluye documentación en cada tarea.
+
+## Examples
+- Milestone de "User Management" con issues por entidad/servicio/controlador.
+- Checklist de aceptación con cobertura > 80%.
+
+## Related Skills
+- tdd-workflow
+- springboot-tdd

--- a/skills/tdd-workflow/SKILL.md
+++ b/skills/tdd-workflow/SKILL.md
@@ -407,3 +407,27 @@ npm test && npm run lint
 ---
 
 **Remember**: Tests are not optional. They are the safety net that enables confident refactoring, rapid development, and production reliability.
+
+# Skill: tdd-workflow
+
+## Purpose
+Aplicar Test-Driven Development con cobertura 80%+ incluyendo unit, integración y E2E.
+
+## When to Use
+- Al desarrollar features nuevas, fixes o refactors.
+- Al crear endpoints o componentes con lógica crítica.
+
+## Usage
+- Define user journeys y casos de prueba.
+- Escribe tests primero, implementa mínimo, refactoriza.
+- Ejecuta cobertura y corrige gaps.
+
+## Examples
+- Unit test con React Testing Library.
+- Integration test de un endpoint.
+- E2E con Playwright para flujos críticos.
+
+## Related Skills
+- tdd-milestone-planning
+- verification-loop
+- springboot-tdd

--- a/skills/verification-loop/SKILL.md
+++ b/skills/verification-loop/SKILL.md
@@ -118,3 +118,24 @@ Run: /verify
 
 This skill complements PostToolUse hooks but provides deeper verification.
 Hooks catch issues immediately; this skill provides comprehensive review.
+
+# Skill: verification-loop
+
+## Purpose
+Ejecutar un ciclo de verificación (build, types, lint, tests, seguridad) antes de PR.
+
+## When to Use
+- Tras completar features o refactors.
+- Antes de crear un PR.
+
+## Usage
+- Ejecuta cada fase en orden y reporta resultados.
+- Detén la entrega si alguna fase crítica falla.
+
+## Examples
+- `npm run build` seguido de `npm run lint`.
+- Revisar diffs con `git diff --stat`.
+
+## Related Skills
+- springboot-verification
+- tdd-workflow


### PR DESCRIPTION
### Motivation
- Standardize skill documentation so each skill exposes the same metadata and usage guidance required by the agent/skill workflows. 
- Improve discoverability and consistency for automated tooling and human readers by making `Purpose`, `When to Use`, `Usage`, `Examples`, and `Related Skills` explicit. 

### Description
- Added a `# Skill: <name>` header and the sections `## Purpose`, `## When to Use`, `## Usage`, `## Examples`, and `## Related Skills` to SKILL.md files under the `skills/` directory. 
- Updated 22 skill files (docs-only edits), for example `skills/springboot-patterns/SKILL.md`, `skills/backend-patterns/SKILL.md`, `skills/frontend-patterns/SKILL.md`, `skills/continuous-learning-v2/SKILL.md`, and `skills/verification-loop/SKILL.md`. 
- Section content is a concise Spanish summary derived from each file's existing material so the new blocks reflect each skill's intent and usage without changing behavior. 

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698a588cf68483218ddd353b2e32fed3)