### PR TITLE
Extend planner-tdd for image prototype intake

### DIFF
--- a/agents/planner-tdd.md
+++ b/agents/planner-tdd.md
@@ -17,6 +17,13 @@ When creating implementation plans, refer to these example artifacts for structu
 
 These files demonstrate the expected format, level of detail, and organization for spec documents. 
 
+## Prototype Inputs (Images Only)
+
+When prototypes are provided, treat the image files in `assets/figma` as the source of truth.
+Only use image-based prototypes for extraction (ignore HTML exports unless explicitly requested).
+The goal is to consolidate the existing `assets/specs` content with new findings from the images,
+ensuring no contradictions and clearly documenting any newly inferred requirements.
+
 ## Your Mission
 
 Create detailed implementation plans organized into milestones and issues that strictly follow TDD principles:
@@ -40,6 +47,13 @@ When given a project description or requirements:
    - Extract any correctness properties from design documents
    - Each property MUST have a corresponding property test
    - Note which properties apply to which components
+
+3. **Image Prototype Extraction** (if `assets/figma` is present):
+   - Enumerate screens and their primary user goals.
+   - Identify UI actions, required fields, states, and error conditions.
+   - Convert UI observations into user stories and acceptance criteria
+     using the requirements template format.
+   - Reconcile with `assets/specs` by merging overlaps and flagging gaps.
 
 ## Milestone Organization
 

--- a/contexts/planner-tdd.md
+++ b/contexts/planner-tdd.md
@@ -106,6 +106,14 @@ When creating implementation plans:
    - Extract business rules
    - Define correctness properties
 
+2.1 **Ingest Image Prototypes (if present)**
+   - Use `assets/figma` image files as primary inputs.
+   - Ignore HTML exports unless explicitly requested.
+   - Derive user stories + acceptance criteria from visible UI states,
+     required fields, and user actions.
+   - Merge with existing `assets/specs` content, preserving numbering and
+     noting any new or conflicting requirements.
+
 3. **Design Architecture**
    - Follow dependency order (Infrastructure → Shared → Core → Domain → Advanced)
    - Define component interfaces
@@ -197,6 +205,15 @@ When creating specs, produce three documents:
 3. **tasks.md**: Milestones + TDD tasks + estimates
 
 Each document should match the structure and detail level of the templates.
+
+## Prototype-to-Spec Consolidation Checklist
+
+Use this checklist when image prototypes exist:
+- [ ] All screens in `assets/figma` are enumerated with a short goal summary
+- [ ] UI actions map to user stories and acceptance criteria
+- [ ] Requirements numbering stays consistent with existing specs
+- [ ] Conflicts or gaps with `assets/specs` are explicitly noted
+- [ ] New properties are added to design and mapped to property tests
 
 ## Notes for Claude Code Compatibility
 


### PR DESCRIPTION
### Motivation
- Provide explicit guidance so the `planner-tdd` agent treats image prototypes in `assets/figma` as the source of truth and consolidates findings with existing `assets/specs` content.
- Enable converting visual UI artifacts into requirements, user stories, acceptance criteria, and property tests to preserve the TDD-first planning workflow.

### Description
- Add a `Prototype Inputs (Images Only)` section to `agents/planner-tdd.md` instructing planners to use `assets/figma` images and to ignore HTML exports unless requested.
- Add an `Image Prototype Extraction` step in `agents/planner-tdd.md` describing enumeration of screens, identification of UI actions/fields/states, and conversion into requirements-format acceptance criteria.
- Add `Ingest Image Prototypes` guidance and a `Prototype-to-Spec Consolidation Checklist` to `contexts/planner-tdd.md` to document reconciliation rules, numbering preservation, and mapping of new properties to property tests.
- Modifications are documentation-only and touch `agents/planner-tdd.md` and `contexts/planner-tdd.md`.

### Testing
- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698a722363088321b2ecf4d3951712c4)