### PR TITLE
feat: Configure Gradle Multi-Module Project (Issue 1.1)

### DIFF
--- a/application/src/main/java/com/cookiesstore/CookiesStoreApplication.java
+++ b/application/src/main/java/com/cookiesstore/CookiesStoreApplication.java
@@ -1,0 +1,15 @@
+package com.cookiesstore;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Main entry point for the Cookies Store E-Commerce application.
+ */
+@SpringBootApplication
+public class CookiesStoreApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CookiesStoreApplication.class, args);
+    }
+}

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: cookies-store
+  
+  profiles:
+    active: default

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,8 +19,9 @@ subprojects {
     apply(plugin = "io.spring.dependency-management")
     
     java {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        }
     }
     
     dependencies {
@@ -31,5 +32,24 @@ subprojects {
     
     tasks.test {
         useJUnitPlatform()
+    }
+    
+    // Disable bootJar for library modules, enable jar
+    tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
+        enabled = false
+    }
+    
+    tasks.named<Jar>("jar") {
+        enabled = true
+    }
+}
+
+// Enable bootJar only for the application module
+project(":application") {
+    tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
+        enabled = true
+    }
+    tasks.named<Jar>("jar") {
+        enabled = false
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,10 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m --add-opens=java.base/java.lang=ALL-UNNAMED
 
 # Project version
 version=0.1.0
+
+# Kotlin version compatibility
+kotlin.stdlib.default.dependency=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-rc-4-bin.zip
-networkTimeout=10000
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+networkTimeout=120000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
Configures the Gradle multi-module project structure with proper bootJar configuration.

## Changes
- Fix bootJar configuration: disabled for library modules, enabled only for application
- Add CookiesStoreApplication main class
- Configure application.yml for Spring Boot
- Update gradle wrapper to use stable version
- Extract versions to gradle.properties

## TDD Status
- **RED**: Verified build fails without main class
- **GREEN**: Build succeeds with all modules compiling
- **REFACTOR**: Extracted bootJar config to root build.gradle.kts

## Acceptance Criteria
- [x] Estructura multi-module creada
- [x] `./gradlew build` ejecuta exitosamente
- [x] Todos los módulos compilan

Closes #10